### PR TITLE
Replace html/template with text/template

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
+	"text/template"
 
 	alerttemplate "github.com/prometheus/alertmanager/template"
 	"github.com/spf13/viper"


### PR DESCRIPTION
The the html/template package escapes certain special characters such as
`"`.  If the messages received from Alertmanager contain these special
characters they will show up HTML-encoded in the chat message.

    summary: Server &#34;foo&#34; is down

instead of:

    summary: Server "foo" is down

This patch relaces html/template with text/template because there's no
need for special HTML escape rules to generate a notification message.

Resolves #7

Signed-off-by: David Wagner <david.wagner@pix4d.com>