### PR TITLE
fix: split messages at maximum size supported by webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ To help you quickly get started, you can `POST` a dummy payload which is similar
 -   **[app]**
 
     -   **template_file**: Path to template file used for parsing Alertmanager payload to Google Chat message. You can configure the default template for notification and create your own. Create a [template](https://golang.org/pkg/text/template/) file, similar to [message.tmpl](message.tmpl) and set the path of this file in this setting.
+    -   **max_size**: The maximum size of a single push to the webhook URL.
+    -   **http_client**
+        -   **max_idle_conns**: _Optional_, Maximum count of keep-alive collections per host.
+        -   **request_timeout**: Duration (in milliseconds) to wait for the response.
+    -   **chat.your_room_name**
+        -   **notification_url**: Webhook URL of Google Chat Room where Incoming Webhooks are configured.
     -   **http_client**
         -   **max_idle_conns**: _Optional_, Maximum count of keep-alive collections per host.
         -   **request_timeout**: Duration (in milliseconds) to wait for the response.

--- a/config.toml.sample
+++ b/config.toml.sample
@@ -13,6 +13,7 @@ keepalive_timeout=300000
 
 [app]
 template_file = "message.tmpl"
+max_size = 4000
 
 [app.http_client]
 max_idle_conns =  100

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func initConfig() {
 	viper.SetDefault("server.read_timeout", 1000)
 	viper.SetDefault("server.write_timeout", 5000)
 	viper.SetDefault("server.keepalive_timeout", 30000)
+	viper.SetDefault("app.max_size", 4000)
 	// Process flags.
 	flagSet.Parse(os.Args[1:])
 	viper.BindPFlags(flagSet)


### PR DESCRIPTION
Google Chat supports a maximum of 4096-bytes per message.
Introduce a new max_size variable which allows setting the size to chunk individual messages at.

This achieves the same goal as [PR#9](https://github.com/mr-karan/calert/pull/9) but without assuming a message size.
