### PR TITLE
Helm chart: Add back null receiver to alertmanager example config

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -53,12 +53,14 @@ The following changes should be made in the Alertmanager section of the `prometh
 alertmanager:
   config:
     route:
+      receiver: "null"
       routes:
       - match:
           severity: critical
         receiver: google-chat
         group_by: [alertname]
     receivers:
+    - name: "null"
     - name: 'google-chat'
       webhook_configs:
       - url: "http://calert.clu-inf-all.svc.cluster.local:6000/create?room_name=<room>"


### PR DESCRIPTION
See https://github.com/patrickmslatteryvt/calert/pull/2 for details. 
Moved that PR here now since #3 is now closed.