### PR TITLE
Helm chart: set message.tmpl using values

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -30,6 +30,7 @@ configmap:
 | `image.tag`                                 | Docker image tag                                                 | 1.0.0-stable                    |
 | `image.pullPolicy`                          | Docker image pull policy                                         | Always                          |
 | `replicaCount`                              | Number of pod replicas                                           | 1                               |
+| `template_file`                             | Content of Application template file                             | "..." (see values)              |
 | `configmap.server.address`                  | Port that the app listens to in the pod                          | ":6000"                         |
 | `configmap.server.socket`                   | Socket that the app listens to in the pod                        | "/tmp/calert.sock"              |
 | `configmap.server.name`                     | Name for the server instance                                     | "calert"                        |

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -8,6 +8,7 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
+  message.tmpl: {{- toYaml .Values.template_file | indent 4 }}
   config.toml: |
     # All timeouts and durations are in milliseconds.
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         app.kubernetes.io/name: {{ include "calert.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -59,6 +62,8 @@ spec:
             items:
             - key: config.toml
               path: config.toml
+            - key: message.tmpl
+              path: message.tmpl
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,6 +25,12 @@ configmap:
     [app.chat.awesomeRoomTwo]
     notification_url = "https://chat.googleapis.com/v1/spaces/xxx/messages?key=abc-xyz&token=token-unique-key%3D"
 
+template_file: |
+  *{{ .Labels.alertname | Title }} - {{.Status | Title }} ({{.Labels.severity | toUpper }})*
+  {{ range .Annotations.SortedPairs -}}
+  {{ .Name }}: {{ .Value}}
+  {{ end -}}
+
 replicaCount: 1
 
 image:


### PR DESCRIPTION
## Why

I'd like to be able to override the [`message.tmpl`](https://github.com/mr-karan/calert/blob/master/message.tmpl) file, so here's a PR for doing that in the helm chart.

## What

Here's an example:

### 1. Using your custom values for `message.tmpl`:

```go
$ cat my-values.yaml
template_file: |
  *{{ .Labels.alertname | Title }} - {{.Status | Title }} ({{.Labels.severity | toUpper }})*
  Instance: {{.Labels.instance}}
  {{ range .Annotations.SortedPairs -}}
  {{ .Name }}: {{ .Value}}
  {{ end -}}
```

### 2. Install the chart:

```bash
$ helm install -f my-values.yaml calert ./helm/
[...]
```

### 3. Check the config:

```go
$ kubectl exec -it calert-69b54bc5f6-gzpqd cat /etc/calert/message.tmpl
*{{ .Labels.alertname | Title }} - {{.Status | Title }} ({{.Labels.severity | toUpper }})*
Instance: {{.Labels.instance}}
{{ range .Annotations.SortedPairs -}}
{{ .Name }}: {{ .Value}}
{{ end -}}%
```