### PR TITLE
Helm chart: set message.tmpl to mounted configmap

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -37,7 +37,7 @@ configmap:
 | `configmap.server.read_timeout`             | Read timeout in milliseconds                                     | "8000"                          |
 | `configmap.server.write_timeout`            | Write timeout in milliseconds                                    | "8000"                          |
 | `configmap.server.keepalive_timeout`        | Keepalive timeout in milliseconds                                | "300000"                        |
-| `configmap.app.template_file`               | Application template file                                        | "message.tmpl"                  |
+| `configmap.app.template_file`               | Application template file                                        | "/etc/calert/message.tmpl"      |
 | `configmap.app.http_client.max_idle_conns`  | Client max idele connections                                     | "100"                           |
 | `configmap.app.http_client.request_timeout` | Client request timeout in milliseconds                           | "8000"                          |
 | `configmap.rooms`                           | List of webhooks to send to. See `calert_values.yaml` above      | [app.chat.alertManagerTestRoom] |

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -13,7 +13,7 @@ configmap:
     write_timeout: "8000"
     keepalive_timeout: "300000"
   app:
-    template_file: "message.tmpl"
+    template_file: "/etc/calert/message.tmpl"
     http_client:
       max_idle_conns: "100"
       request_timeout: "8000"


### PR DESCRIPTION
In #16 I had accidentally forgotten to configure calert to use the new file created by the configmap. This fixes that (I've also tested it in my cluster — getting alerts with my custom template).