### PR TITLE
Offers the possibility to use an internal proxy.

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -18,6 +18,7 @@ max_size = 4000
 [app.http_client]
 max_idle_conns =  100
 request_timeout = 8000
+proxy_url = "http://internal-squid-proxy.com:3128"
 
 [app.chat.alertManagerTestRoom]
 notification_url = "https://chat.googleapis.com/v1/spaces/xxx/messages?key=abc-xyz&token=token-unique-key%3D"

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -30,6 +30,7 @@ data:
     [app.http_client]
     max_idle_conns = {{ .Values.configmap.app.http_client.max_idle_conns }}
     request_timeout = {{ .Values.configmap.app.http_client.request_timeout }}
+    proxy_url = {{ .Values.configmap.app.http_client.proxy_url }}
 
     {{- with .Values.configmap.rooms }}
     {{ tpl . $ | indent 4 }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
     [app.http_client]
     max_idle_conns = {{ .Values.configmap.app.http_client.max_idle_conns }}
     request_timeout = {{ .Values.configmap.app.http_client.request_timeout }}
-    proxy_url = {{ .Values.configmap.app.http_client.proxy_url }}
+    proxy_url = {{ .Values.configmap.app.http_client.proxy_url | quote }}
 
     {{- with .Values.configmap.rooms }}
     {{ tpl . $ | indent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -18,6 +18,7 @@ configmap:
     http_client:
       max_idle_conns: "100"
       request_timeout: "8000"
+      proxy_url: "http://internal-squid-proxy.com:3128"
   rooms: |
 
     [app.chat.alertManagerTestRoom]

--- a/kustomize/overlays/prod/raw/config.toml
+++ b/kustomize/overlays/prod/raw/config.toml
@@ -17,7 +17,7 @@ template_file = "message.tmpl"
 [app.http_client]
 max_idle_conns =  100
 request_timeout = 8000
-proxy_url = "http://115.124.92.42:8080"
+proxy_url = "http://internal-squid-proxy.com:3128"
 
 [app.chat.alertManagerTestRoom]
 notification_url = "https://chat.googleapis.com/v1/spaces/xxx/messages?key=abc-xyz&token=token-unique-key%3D"

--- a/kustomize/overlays/prod/raw/config.toml
+++ b/kustomize/overlays/prod/raw/config.toml
@@ -17,6 +17,7 @@ template_file = "message.tmpl"
 [app.http_client]
 max_idle_conns =  100
 request_timeout = 8000
+proxy_url = "http://115.124.92.42:8080"
 
 [app.chat.alertManagerTestRoom]
 notification_url = "https://chat.googleapis.com/v1/spaces/xxx/messages?key=abc-xyz&token=token-unique-key%3D"

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func initClient() *http.Client {
 
 		proxyURL, err := url.Parse(proxyURLString)
 		if err != nil {
-			errLog.Fatalf("Error enter proxy_url: %s", err)
+			errLog.Fatalf("Unable to parse `proxy_url`: %s", err)
 		}
 
 		transport.Proxy = http.ProxyURL(proxyURL)

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"time"
 
@@ -70,6 +71,7 @@ func initConfig() {
 	viper.SetDefault("server.read_timeout", 1000)
 	viper.SetDefault("server.write_timeout", 5000)
 	viper.SetDefault("server.keepalive_timeout", 30000)
+	viper.SetDefault("app.http_client.proxy_url", "")
 	viper.SetDefault("app.max_size", 4000)
 	// Process flags.
 	flagSet.Parse(os.Args[1:])
@@ -92,13 +94,29 @@ func initConfig() {
 }
 
 func initClient() *http.Client {
+
+	transport := &http.Transport{
+		MaxIdleConnsPerHost:   viper.GetInt("app.http_client.max_idle_conns"),
+		ResponseHeaderTimeout: time.Duration(viper.GetDuration("app.http_client.request_timeout") * time.Millisecond),
+	}
+
+	proxyURLString := viper.GetString("app.http_client.proxy_url")
+
+	if proxyURLString != "" {
+
+		proxyURL, err := url.Parse(proxyURLString)
+		if err != nil {
+			errLog.Fatalf("Error enter proxy_url: %s", err)
+		}
+
+		transport.Proxy = http.ProxyURL(proxyURL)
+	}
+
 	// Generic HTTP handler for communicating with the Chat webhook endpoint.
 	return &http.Client{
-		Timeout: time.Duration(viper.GetDuration("app.http_client.request_timeout") * time.Millisecond),
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost:   viper.GetInt("app.http_client.max_idle_conns"),
-			ResponseHeaderTimeout: time.Duration(viper.GetDuration("app.http_client.request_timeout") * time.Millisecond),
-		}}
+		Timeout:   time.Duration(viper.GetDuration("app.http_client.request_timeout") * time.Millisecond),
+		Transport: transport}
+
 }
 
 // prog initialisation.


### PR DESCRIPTION
With this extension it is possible to enter a http proxy via the viper config structure. Basically you could also use the classic ENV variables `$HTTP_PROXY` etc.. However, I find the way to solve it via the config a bit more sharp because the proxy information refers only to the application and not for the environment. In some cases this may not be desired, because it expects a number of `NO_PROXY` entries.

I hope I can improve this nice little application a bit and I would be happy about the integration into the master branch.