### PR TITLE
Avoid null pointer exception for string interpolation

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,9 @@ type Handler struct {
 func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	code, msg, data, et, err := h.HandleRequest(h.App, w, r)
 	if et != "" {
-		errLog.Printf("Error while processing request: %s", err)
+		if err != nil {
+			errLog.Printf("Error while processing request: %s", err)
+		}
 		sendErrorEnvelope(w, code, msg, data, et)
 	} else {
 		sendEnvelope(w, code, msg, data)


### PR DESCRIPTION
Under certain conditions, such as a config error `room not found` etc.. This results in an unsightly log entry without any indication of the error itself. The caller gets the message as a response. However one can reject these log entries, if err == nil. 

Log-entry
```calert/main.go:45: Error while processing request: %!s(<nil>) ```