### PR TITLE
some improvements for the helm chart

### DIFF
--- a/contrib/helm/Chart.yaml
+++ b/contrib/helm/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 appVersion: 2.0.2
 description: A Helm chart for the calert which uses Alertmanager webhook receiver to receive alerts payload, and pushes this data to Google Chat webhook endpoint.
 name: calert
-version: 2.0.2
+version: 2.0.3
 icon: https://github.com/mr-karan/calert/raw/master/images/logo.png
 home: https://github.com/mr-karan/calert
 sources:
 - https://github.com/mr-karan/calert
 maintainers:
 - name: Karan Sharma
-  email: karansharma1295@gmail.com
+  email: hello@mrkaran.dev

--- a/contrib/helm/README.md
+++ b/contrib/helm/README.md
@@ -1,12 +1,12 @@
 # calert
 
-![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
+![Version: 2.0.3](https://img.shields.io/badge/Version-2.0.3-informational?style=flat-square) ![AppVersion: 2.0.2](https://img.shields.io/badge/AppVersion-2.0.2-informational?style=flat-square)
 
 A Helm chart for the calert which uses Alertmanager webhook receiver to receive alerts payload, and pushes this data to Google Chat webhook endpoint.
 
-**Homepage:** <https://github.com/mr-karan/calert>
+**Source Code:** <https://github.com/mr-karan/calert>
 
-## Alertmanager Integration
+# Alertmanager Integration
 
 The Alertmanager helm chart can be found [here](https://github.com/prometheus-community/helm-charts/tree/main/charts/alertmanager). You can refer to the following config block to route webhook alerts to `calert`:
 
@@ -25,56 +25,35 @@ config:
     group_by: ['alertname']
 ```
 
-## Maintainers
+# Parameters
 
-| Name | Email | Url |
-| ---- | ------ | --- |
-| Karan Sharma | <karansharma1295@gmail.com> |  |
+The following tables lists the configurable parameters of the chart and their default values.
 
-## Source Code
-
-* <https://github.com/mr-karan/calert>
-
-## Values
+Change the values according to the need of the environment in ``contrib/helm/values.yaml`` file.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| args[0] | string | `"--config=/app/static/config.toml"` |  |
-| configmap.app.address | string | `"0.0.0.0:6000"` |  |
-| configmap.app.enable_request_logs | bool | `true` |  |
-| configmap.app.log | string | `"info"` |  |
-| configmap.app.server_timeout | string | `"5s"` |  |
-| configmap.providers.dev_alerts.dry_run | bool | `false` |  |
-| configmap.providers.dev_alerts.endpoint | string | `"https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"` |  |
-| configmap.providers.dev_alerts.max_idle_conns | int | `50` |  |
-| configmap.providers.dev_alerts.proxy_url | string | `"http://internal-squid-proxy.com:3128"` |  |
-| configmap.providers.dev_alerts.template | string | `"static/message.tmpl"` |  |
-| configmap.providers.dev_alerts.thread_ttl | string | `"12h"` |  |
-| configmap.providers.dev_alerts.timeout | string | `"7s"` |  |
-| configmap.providers.dev_alerts.type | string | `"google_chat"` |  |
-| configmap.providers.prod_alerts.dry_run | bool | `false` |  |
-| configmap.providers.prod_alerts.endpoint | string | `"https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"` |  |
-| configmap.providers.prod_alerts.max_idle_conns | int | `50` |  |
-| configmap.providers.prod_alerts.proxy_url | string | `"http://internal-squid-proxy.com:3128"` |  |
-| configmap.providers.prod_alerts.template | string | `"static/message.tmpl"` |  |
-| configmap.providers.prod_alerts.thread_ttl | string | `"12h"` |  |
-| configmap.providers.prod_alerts.timeout | string | `"7s"` |  |
-| configmap.providers.prod_alerts.type | string | `"google_chat"` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/mr-karan/calert"` |  |
-| image.tag | string | `"latest"` |  |
-| ingress.enabled | bool | `false` |  |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
+| app.address | string | `"0.0.0.0:6000"` |  |
+| app.server_timeout | string | `"60s"` |  |
+| app.enable_request_logs | bool | `true` |  |
+| app.log | string | `"info"` |  |
+| providers | object | `{}` |  |
+| templates | object | `{}` |  |
 | replicaCount | int | `1` |  |
+| image.repository | string | `"ghcr.io/mr-karan/calert"` |  |
+| image.tag | string | `"v2.0.2"` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| args[0] | string | `"--config=/app/static/config.toml"` |  |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| service.type | string | `"ClusterIP"` |  |
+| service.port | int | `6000` |  |
+| ingress.enabled | bool | `false` |  |
 | resources.limits.cpu | string | `"20m"` |  |
 | resources.limits.memory | string | `"48Mi"` |  |
 | resources.requests.cpu | string | `"5m"` |  |
 | resources.requests.memory | string | `"24Mi"` |  |
-| service.port | int | `6000` |  |
-| service.type | string | `"ClusterIP"` |  |
+| nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
-
-----------------------------------------------
+| affinity | object | `{}` |  |
+| podAnnotations | object | `{}` |  |

--- a/contrib/helm/templates/configmap.yaml
+++ b/contrib/helm/templates/configmap.yaml
@@ -8,35 +8,27 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-  message.tmpl: {{- toYaml .Values.template_file | indent 4 }}
+  {{- range $key, $value := .Values.templates }}
+  {{ $key }}: |-
+    {{- $value | nindent 4 }}
+  {{- end }}
   config.toml: |
     # All timeouts and durations are in milliseconds.
+
     [app]
-    address = {{ .Values.configmap.app.address | quote }}
-    server_timeout = {{ .Values.configmap.app.server_timeout | quote }}
-    enable_request_logs = {{ .Values.configmap.app.enable_request_logs | quote }}
-    log = {{ .Values.configmap.app.enable_request_logs | quote }}
+    address = {{ .Values.app.address | quote }}
+    server_timeout = {{ .Values.app.server_timeout | quote }}
+    enable_request_logs = {{ .Values.app.enable_request_logs | quote }}
+    log = {{ .Values.app.log | quote }}
 
-    [providers.prod_alerts]
-    type = {{ .Values.configmap.providers.prod_alerts.type | quote }}
-    endpoint = {{ .Values.configmap.providers.prod_alerts.endpoint | quote }}
-    max_idle_conns = {{ .Values.configmap.providers.prod_alerts.max_idle_conns | quote }}
-    timeout = {{ .Values.configmap.providers.prod_alerts.timeout | quote }}
-    proxy_url = {{ .Values.configmap.providers.prod_alerts.proxy_url | quote }}
-    template = {{ .Values.configmap.providers.prod_alerts.template | quote }}
-    thread_ttl = {{ .Values.configmap.providers.prod_alerts.thread_ttl | quote }}
-    dry_run = {{ .Values.configmap.providers.prod_alerts.dry_run | quote }}
-
-    [providers.dev_alerts]
-    type = {{ .Values.configmap.providers.dev_alerts.type | quote }}
-    endpoint = {{ .Values.configmap.providers.dev_alerts.endpoint | quote }}
-    max_idle_conns = {{ .Values.configmap.providers.dev_alerts.max_idle_conns | quote }}
-    timeout = {{ .Values.configmap.providers.dev_alerts.timeout | quote }}
-    proxy_url = {{ .Values.configmap.providers.dev_alerts.proxy_url | quote }}
-    template = {{ .Values.configmap.providers.dev_alerts.template | quote }}
-    thread_ttl = {{ .Values.configmap.providers.dev_alerts.thread_ttl | quote }}
-    dry_run = {{ .Values.configmap.providers.dev_alerts.dry_run | quote }}
-
-    {{- with .Values.configmap.rooms }}
-    {{ tpl . $ | indent 4 }}
+    {{- range $key, $value := .Values.providers }}
+    [providers.{{ $key }}]
+    type = {{ $value.type | default "google_chat" | quote }}
+    endpoint = {{ required "setting a endpoint for providers is requiered" $value.endpoint | quote }}
+    max_idle_conns = {{ $value.max_idle_conns | default "50" }}
+    timeout = {{ $value.timeout | default "30s" | quote }}
+    proxy_url = {{ $value.proxy_url | default "" | quote }}
+    template = {{ $value.template | default "static/message.tmpl" | quote }}
+    thread_ttl = {{ $value.thread_ttl | default "12h" | quote }}
+    dry_run = {{ $value.dry_run | default "false" | quote }}
     {{- end }}

--- a/contrib/helm/templates/deployment.yaml
+++ b/contrib/helm/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       annotations:
         # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "calert.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -66,8 +69,10 @@ spec:
             items:
             - key: config.toml
               path: config.toml
-            - key: message.tmpl
-              path: message.tmpl
+            {{- range $key, $value := .Values.templates }}
+            - key: {{ $key }}
+              path: {{ $key }}
+            {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/helm/values.yaml
+++ b/contrib/helm/values.yaml
@@ -2,76 +2,51 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-configmap:
-    # All timeouts and durations are in milliseconds.
-  app:
-    # Address of the HTTP Server.
-    address: "0.0.0.0:6000"
-    # Server timeout for HTTP requests.
-    server_timeout: "60s"
-    # Whether to log incoming HTTP requests or not.
-    enable_request_logs: true
-    # Use `debug` to enable verbose logging. Can be set to `info` otherwise.
-    log: "info"
-  providers:
-    prod_alerts:
-      # Type of provider. Currently supported value is `google_chat`.
-      type: "google_chat"
-      # Google Chat Webhook URL
-      endpoint: "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"
-      # Max idle connections in the HTTP Client.
-      max_idle_conns: 50
-      # Timeout for making requests to Provider.
-      timeout: "30s"
-      # Specify `proxy_url` as your proxy endpoint to route all HTTP requests to the provider via a proxy.
-      proxy_url: "http://internal-squid-proxy.com:3128"
-      # Path to specify the message template path.
-      template: "static/message.tmpl"
-      # Timeout to keep active alerts in memory. Once this TTL expires, a new thread will be created.
-      thread_ttl: "12h"
-      # In case you're simply experimenting with calert config changes and you don't wish to send actual notifications,
-      # you can set dry_run=true in each provider.
-      dry_run: false
-    dev_alerts:
-      # Type of provider. Currently supported value is `google_chat`.
-      type: "google_chat"
-      # Google Chat Webhook URL
-      endpoint: "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"
-      # Max idle connections in the HTTP Client.
-      max_idle_conns: 50
-      # Timeout for making requests to Provider.
-      timeout: "30s"
-      # Specify `proxy_url` as your proxy endpoint to route all HTTP requests to the provider via a proxy.
-      proxy_url: "http://internal-squid-proxy.com:3128"
-      # Path to specify the message template path.
-      template: "static/message.tmpl"
-      # Timeout to keep active alerts in memory. Once this TTL expires, a new thread will be created.
-      thread_ttl: "12h"
-      # In case you're simply experimenting with calert config changes and you don't wish to send actual notifications,
-      # you can set dry_run=true in each provider.
-      dry_run: false
-  rooms: |
-    [providers.calert]
-    type = "google_chat"
-    endpoint = "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"
-    max_idle_conns = 50
-    timeout = "7s"
-    #proxy_url = "http://internal-squid-proxy.com:3128"
-    template = "static/message.tmpl"
-    thread_ttl = "12h"
-    dry_run = false
+# All timeouts and durations are in milliseconds.
+app:
+  address: "0.0.0.0:6000" # Address of the HTTP Server.
+  server_timeout: "60s" # Server timeout for HTTP requests.
+  enable_request_logs: true # Whether to log incoming HTTP requests or not.
+  log: "info" # Use `debug` to enable verbose logging. Can be set to `info` otherwise.
 
-template_file: |
-  *({{.Labels.severity | toUpper }}) {{ .Labels.alertname | Title }} - {{.Status | Title }}*
-  {{ range .Annotations.SortedPairs -}}
-  {{ .Name | Title }}: {{ .Value}}
-  {{ end -}}
+# https://github.com/mr-karan/calert/blob/main/config.sample.toml
+providers: {}
+  # prod_alerts:
+  #   type: "google_chat" # Type of provider. Currently supported value is `google_chat`.
+  #   endpoint: "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D" # Google Chat Webhook URL
+  #   max_idle_conns:  50 # Max idle connections in the HTTP Client.
+  #   timeout: "30s" # Timeout for making requests to Provider.
+  #   proxy_url: "http://internal-squid-proxy.com:3128" # Specify `proxy_url` as your proxy endpoint to route all HTTP requests to the provider via a proxy.
+  #   template: "static/message.tmpl" # Path to specify the message template path.
+  #   thread_ttl: "12h" # Timeout to keep active alerts in memory. Once this TTL expires, a new thread will be created.
+  #   dry_run: false
+
+  # qa_alerts:
+  #   endpoint: "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"
+
+  # dev_alerts:
+  #   endpoint: "https://chat.googleapis.com/v1/spaces/xxx/messages?key=key&token=token%3D"
+  #   template: "static/dev_alerts.tmpl"
+  #   dry_run: true
+
+templates: {}
+  # message.tmpl: |
+  #   *({{.Labels.severity | toUpper }}) {{ .Labels.alertname | Title }} - {{.Status | Title }}*
+  #   {{ range .Annotations.SortedPairs -}}
+  #   {{ .Name | Title }}: {{ .Value}}
+  #   {{ end -}}
+
+  # dev_alerts.tmpl: |
+  #   *({{.Labels.severity | toUpper }}) {{ .Labels.alertname | Title }} - {{.Status | Title }}*
+  #   {{ range .Annotations.SortedPairs -}}
+  #   {{ .Name | Title }}: {{ .Value}}
+  #   {{ end -}}
 
 replicaCount: 1
 
 image:
   repository: ghcr.io/mr-karan/calert
-  tag: latest
+  tag: v2.0.2
   pullPolicy: Always
 
 args:
@@ -100,3 +75,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
Hello mr-karan,

First of all I want to thank you for creating and maintaining this wonderful tool!

I took the time to customize the Helm chart previously updated by @weibo-zhao.

Currently when deploying, "prod_alerts" and "dev_alerts" are always added to the configuration and initialised in Calert.
You can change the individual values of the provider but you are tied to the names "prod_alerts" and "dev_alerts"

### Below I will briefly describe my changes:
- Added the possibility to create one or more providers and configure the name and each value individually without having to chop everything into a config string (like in "configmap.rooms")
- Added the possibility to create one or more message templates, which can later be used to send different messages for each provider (using template = "static/<name>.tmpl).
- Included the option to add annotations to the Calert pod. Just a very small change to use if needed :grinning: 

### I am currently struggling with an issue regarding the second change
Let us look at it with the following scenario:
Using my Helm chart, we configured two providers, both using google_chat for notification.
- Provider1 has been configured to use 'template = "static/message.tmpl"' and send its message without any problems.
- Provider2 has been configured to use 'template = "static/text.tmpl"' and is getting the following error message

```
level=error msg="Error parsing values in template" error="template: message.tmpl: \"message.tmpl\" is an incomplete or empty template"
level=error msg="error preparing message" error="template: message.tmpl: \"message.tmpl\" is an incomplete or empty template"
```

Calert always seems to be expecting a message.tmpl file and cannot process a different name (text.tmpl in this case).
Am i missing something or is this behavior intentional? :thinking: 

**Despite the mentioned issue, the deployment of Calert, the creation of different providers and templates still works!**
For now, people using this changes just have to stick to the default template name "message.tmpl" (template = "static/message.tmpl").

I look forward reading your opinion on this PR
Thanks in advance!