### PR TITLE
add arm64 to goreleaser builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
       - linux
     goarch:
       - amd64
+      - arm64
     ldflags:
       - -s -w -X "main.buildString={{ .Tag }} ({{ .ShortCommit }} {{ .Date }})"
     dir: ./cmd/


### PR DESCRIPTION
Hi and thank you very much for this project!

We are currently migrating some of our instances to ARM-based builds and `calert` is one of the few things keeping us from doing so for our monitoring stack.

I have only tested building locally on macOS with `goreleaser build --snapshot` so far, but currently lack the resources to test this any further. I am, however, fairly confident that this should "just work" (famous last words, I know).

I also didn't extend the `dockers` section because I didn't want to introduce a tag naming scheme, etc.