### PR TITLE
Adding room_name query arg back so it is flexible to use. Also for backward compatibility.

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -94,10 +94,15 @@ func handleDispatchNotif(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app.lo.WithField("receiver", payload.Receiver).Info("dispatching new alert")
+	roomName := r.URL.Query().Get("room_name")
+	if roomName == "" {
+		roomName = payload.Receiver
+	}
+
+	app.lo.WithField("receiver", roomName).Info("dispatching new alert")
 
 	// Dispatch a list of alerts via Notifier.
-	if err := app.notifier.Dispatch(payload.Alerts, payload.Receiver); err != nil {
+	if err := app.notifier.Dispatch(payload.Alerts, roomName); err != nil {
 		app.lo.WithError(err).Error("error dispatching alerts")
 		app.metrics.Increment(`http_request_errors_total{handler="dispatch"}`)
 		sendErrorResponse(w, "Error dispatching alerts.", http.StatusInternalServerError, nil)


### PR DESCRIPTION
We have a complicated setup where a single receiver has multiple notification methods, e.g. slack + webhook + pagerduty and it's not flexible to rename all receivers just because calert is expecting it as a room name. Moreover, sometimes we have receivers with similar configs but slightly different to serve various use cases, so the name can also be specific and not necessarily match the Google Spaces room name.