### PR TITLE
add possible to configure priorityClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ config.toml
 bin/
 data/
 dist/
+*.idea/

--- a/contrib/helm/calert/README.md
+++ b/contrib/helm/calert/README.md
@@ -53,6 +53,7 @@ Change the values according to the need of the environment in ``contrib/helm/cal
 | resources.limits.memory | string | `"48Mi"` |  |
 | resources.requests.cpu | string | `"5m"` |  |
 | resources.requests.memory | string | `"24Mi"` |  |
+| priorityClassName | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
 | affinity | object | `{}` |  |

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -70,6 +70,8 @@ resources:
     cpu: 5m
     memory: 24Mi
 
+priorityClassName: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Add the possible to configure priorityClass for the calert Deployment.


Priority Classes are used by the Kube Scheduler in the scheduling of Pods.
https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/