### PR TITLE
feat: Add support for topologySpreadConstraints

### DIFF
--- a/contrib/helm/calert/README.md
+++ b/contrib/helm/calert/README.md
@@ -57,4 +57,5 @@ Change the values according to the need of the environment in ``contrib/helm/cal
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
 | affinity | object | `{}` |  |
+| topologySpreadConstraints | list | `[]` |  |
 | podAnnotations | object | `{}` |  |

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -78,4 +78,6 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 podAnnotations: {}


### PR DESCRIPTION
Add support for [Pod topologySpreadConstraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)