### PR TITLE
[feat] Add support for configuring SecurityContext via Helm chart

### DIFF
--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
     {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
+    {{- if .Values.securityContext.enabled }}
+      {{- with omit .Values.securityContext "enabled" }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
             {{- range .Values.args }}
             - {{ . | quote }}
             {{- end }}
+        {{- if .Values.securityContext.enabled }}
+          {{- with omit .Values.securityContext "enabled" "runAsGroup" "runAsUser" "runAsNonRoot" "windowsOptions" }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
           ports:
           - containerPort: {{ .Values.service.port }}
             protocol: TCP

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -81,3 +81,18 @@ affinity: {}
 topologySpreadConstraints: []
 
 podAnnotations: {}
+
+securityContext:
+  enabled: true
+
+  privileged: false
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1001
+  runAsGroup: 1001
+  readOnlyRootFilesystem: true
+  windowsOptions:
+    hostProcess: false
+  capabilities:
+    drop: ["ALL"]
+    add: ["NET_BIND_SERVICE"]

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -83,7 +83,7 @@ topologySpreadConstraints: []
 podAnnotations: {}
 
 securityContext:
-  enabled: true
+  enabled: false
 
   privileged: false
   allowPrivilegeEscalation: false

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -91,6 +91,8 @@ securityContext:
   runAsUser: 1001
   runAsGroup: 1001
   readOnlyRootFilesystem: true
+  seccompProfile:
+    type: RuntimeDefault
   windowsOptions:
     hostProcess: false
   capabilities:


### PR DESCRIPTION
User can enable security context on pod and container level to pass Restricted level of Pod Security Standard - https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted 

Default values already passes the restricted settings on namespace, so it's enough to do
```
securityContext:
  enabled: true
```

By default, this is turned off so it should be no changes for already deployed calert.