### PR TITLE
chore(helm): add custom settings for probes

### DIFF
--- a/contrib/helm/calert/README.md
+++ b/contrib/helm/calert/README.md
@@ -80,3 +80,10 @@ Change the values according to the need of the environment in ``contrib/helm/cal
 | affinity | object | `{}` |  |
 | topologySpreadConstraints | list | `[]` |  |
 | podAnnotations | object | `{}` |  |
+| livenessProbe.initialDelaySeconds | int | `10` |  |
+| livenessProbe.periodSeconds | int | `60` |  |
+| livenessProbe.timeoutSeconds | int | `3` |  |
+| readinessProbe.initialDelaySeconds | int | `10` |  |
+| readinessProbe.periodSeconds | int | `60` |  |
+| readinessProbe.timeoutSeconds | int | `3` |  |
+

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -68,9 +68,9 @@ spec:
                 value: kube-health
               path: "/ping"
               port: {{ .Values.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 60
-            timeoutSeconds: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               httpHeaders:
@@ -78,9 +78,9 @@ spec:
                 value: kube-health
               path: "/ping"
               port: {{ .Values.service.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 60
-            timeoutSeconds: 3
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -98,3 +98,14 @@ securityContext:
   capabilities:
     drop: ["ALL"]
     add: ["NET_BIND_SERVICE"]
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 60
+  timeoutSeconds: 3
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 60
+  timeoutSeconds: 3
+


### PR DESCRIPTION
Hello,

I'm using a custom Docker image that starts faster than the default one.

Setting a lower `periodSeconds` value for the `readinessProbe` helps the pod become ready more quickly.

Therefore, I've added configuration values to allow customization of probe settings.

