### PR TITLE
feat(helm): add startupProbe to replace initialDelaySeconds in others probes

### DIFF
--- a/contrib/helm/calert/README.md
+++ b/contrib/helm/calert/README.md
@@ -80,10 +80,11 @@ Change the values according to the need of the environment in ``contrib/helm/cal
 | affinity | object | `{}` |  |
 | topologySpreadConstraints | list | `[]` |  |
 | podAnnotations | object | `{}` |  |
-| livenessProbe.initialDelaySeconds | int | `10` |  |
 | livenessProbe.periodSeconds | int | `60` |  |
 | livenessProbe.timeoutSeconds | int | `3` |  |
-| readinessProbe.initialDelaySeconds | int | `10` |  |
 | readinessProbe.periodSeconds | int | `60` |  |
 | readinessProbe.timeoutSeconds | int | `3` |  |
+| startupProbe.initialDelaySeconds | int | `0` |  |
+| startupProbe.periodSeconds | int | `10` |  |
+| startupProbe.timeoutSeconds | int | `3` |  |
 

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -68,7 +68,6 @@ spec:
                 value: kube-health
               path: "/ping"
               port: {{ .Values.service.port }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
@@ -78,9 +77,18 @@ spec:
                 value: kube-health
               path: "/ping"
               port: {{ .Values.service.port }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          startupProbe:
+            httpGet:
+              httpHeaders:
+              - name: X-Causation-ID
+                value: kube-health
+              path: "/ping"
+              port: {{ .Values.service.port }}
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -100,12 +100,14 @@ securityContext:
     add: ["NET_BIND_SERVICE"]
 
 livenessProbe:
-  initialDelaySeconds: 10
   periodSeconds: 60
   timeoutSeconds: 3
 
 readinessProbe:
-  initialDelaySeconds: 10
   periodSeconds: 60
   timeoutSeconds: 3
 
+
+startupProbe:
+  periodSeconds: 10
+  timeoutSeconds: 3


### PR DESCRIPTION
`startupProbe` is a better way to wait


Could it be possible to create tags for helm chart versions?