### PR TITLE
Helm: support config as secret

### DIFF
--- a/contrib/helm/calert/templates/_helpers.tpl
+++ b/contrib/helm/calert/templates/_helpers.tpl
@@ -43,3 +43,57 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Render the config.toml content from .Values.app and .Values.providers.
+Shared between the ConfigMap (default) and Secret (when config.asSecret=true) paths.
+*/}}
+{{- define "calert.configToml" -}}
+# All timeouts and durations are in milliseconds.
+
+[app]
+address = {{ .Values.app.address | quote }}
+server_timeout = {{ .Values.app.server_timeout | quote }}
+enable_request_logs = {{ .Values.app.enable_request_logs | quote }}
+log = {{ .Values.app.log | quote }}
+
+{{- range $key, $value := .Values.providers }}
+[providers.{{ $key }}]
+type = {{ $value.type | default "google_chat" | quote }}
+endpoint = {{ required "setting a endpoint for providers is required" $value.endpoint | quote }}
+max_idle_conns = {{ $value.max_idle_conns | default 50 }}
+timeout = {{ $value.timeout | default "30s" | quote }}
+proxy_url = {{ $value.proxy_url | default "" | quote }}
+template = {{ $value.template | default "static/message.tmpl" | quote }}
+thread_ttl = {{ $value.thread_ttl | default "12h" | quote }}
+threaded_replies = {{ $value.threaded_replies | default false }}
+dry_run = {{ $value.dry_run | default false }}
+retry_max = {{ $value.retry_max | default 3 }}
+retry_wait_min = {{ $value.retry_wait_min | default "1s" | quote }}
+retry_wait_max = {{ $value.retry_wait_max | default "5s" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Resolve the name of the Secret or ConfigMap containing config.toml.
+When config.asSecret=true and existingSecret.name is provided, returns that name.
+Otherwise falls back to the generated <fullname>-config name.
+*/}}
+{{- define "calert.configSecretName" -}}
+{{- if .Values.config.existingSecret.name -}}
+{{- .Values.config.existingSecret.name -}}
+{{- else -}}
+{{- template "calert.fullname" . }}-config
+{{- end -}}
+{{- end -}}
+
+{{/*
+Resolve the key within the existing Secret that holds config.toml content.
+*/}}
+{{- define "calert.configSecretKey" -}}
+{{- if .Values.config.existingSecret.name -}}
+{{- .Values.config.existingSecret.key | default "config.toml" -}}
+{{- else -}}
+config.toml
+{{- end -}}
+{{- end -}}

--- a/contrib/helm/calert/templates/configmap.yaml
+++ b/contrib/helm/calert/templates/configmap.yaml
@@ -1,38 +1,17 @@
+{{- if or .Values.templates (not .Values.config.asSecret) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "calert.fullname" . }}-config
   labels:
-    app: {{ template "calert.name" . }}
-    chart: {{ template "calert.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+{{ include "calert.labels" . | indent 4 }}
 data:
   {{- range $key, $value := .Values.templates }}
   {{ $key }}: |-
     {{- $value | nindent 4 }}
   {{- end }}
+  {{- if not .Values.config.asSecret }}
   config.toml: |
-    # All timeouts and durations are in milliseconds.
-
-    [app]
-    address = {{ .Values.app.address | quote }}
-    server_timeout = {{ .Values.app.server_timeout | quote }}
-    enable_request_logs = {{ .Values.app.enable_request_logs | quote }}
-    log = {{ .Values.app.log | quote }}
-
-    {{- range $key, $value := .Values.providers }}
-    [providers.{{ $key }}]
-    type = {{ $value.type | default "google_chat" | quote }}
-    endpoint = {{ required "setting a endpoint for providers is required" $value.endpoint | quote }}
-    max_idle_conns = {{ $value.max_idle_conns | default 50 }}
-    timeout = {{ $value.timeout | default "30s" | quote }}
-    proxy_url = {{ $value.proxy_url | default "" | quote }}
-    template = {{ $value.template | default "static/message.tmpl" | quote }}
-    thread_ttl = {{ $value.thread_ttl | default "12h" | quote }}
-    threaded_replies = {{ $value.threaded_replies | default false }}
-    dry_run = {{ $value.dry_run | default false }}
-    retry_max = {{ $value.retry_max | default 3 }}
-    retry_wait_min = {{ $value.retry_wait_min | default "1s" | quote }}
-    retry_wait_max = {{ $value.retry_wait_max | default "5s" | quote }}
-    {{- end }}
+    {{- include "calert.configToml" . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -13,11 +13,20 @@ spec:
   template:
     metadata:
       annotations:
-        # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- range $key, $value := .Values.podAnnotations }}
-        {{ $key }}: {{ $value | quote }}
+      {{- /*
+        Include checksum/config only if we aren't using an existing secret.
+        https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+      */}}
+      {{- if .Values.config.asSecret }}
+        {{- if not .Values.config.existingSecret.name }}
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
+      {{- else }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- end }}
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "calert.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
@@ -93,8 +102,16 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: config-dir
+        {{- if .Values.config.asSecret }}
+          secret:
+            secretName: {{ include "calert.configSecretName" . }}
+            items:
+              - key: {{ include "calert.configSecretKey" . }}
+                path: config.toml
+        {{- else }}
           configMap:
             name: {{ template "calert.fullname" . }}-config
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/contrib/helm/calert/templates/deployment.yaml
+++ b/contrib/helm/calert/templates/deployment.yaml
@@ -58,6 +58,13 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
         {{- end }}
+        {{- if .Values.env }}
+          env:
+          {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
           ports:
           - containerPort: {{ .Values.service.port }}
             protocol: TCP

--- a/contrib/helm/calert/templates/secret.yaml
+++ b/contrib/helm/calert/templates/secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.config.asSecret (not .Values.config.existingSecret.name) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "calert.fullname" . }}-config
+  labels:
+{{ include "calert.labels" . | indent 4 }}
+type: Opaque
+data:
+  config.toml: {{ include "calert.configToml" . | b64enc | quote }}
+{{- end }}

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -94,6 +94,12 @@ image:
 args:
   - "--config=/app/config.toml"
 
+# -- Environment variables to set on the container (key/value map).
+# Example:
+#   env:
+#     TZ: "America/Vancouver"
+env: {}
+
 # -- Override the name of the chart
 nameOverride: ""
 # -- Override the full name of the chart

--- a/contrib/helm/calert/values.yaml
+++ b/contrib/helm/calert/values.yaml
@@ -2,6 +2,28 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Configuration storage options for config.toml.
+# WARNING: config.toml may contain sensitive values (webhook URLs, API keys).
+# Review config.sample.toml for all available options:
+# https://github.com/mr-karan/calert/blob/main/config.sample.toml
+#
+# When `asSecret` is true AND `existingSecret.name` is set, the `app` and `providers`
+# sections below are IGNORED and config is read from the referenced secret instead.
+config:
+  # -- Store config.toml in a Kubernetes Secret instead of a ConfigMap.
+  # Set to `true` if your config contains sensitive values such as webhook URLs
+  # or API keys. Defaults to `false` for backwards compatibility.
+  asSecret: false
+
+  # -- Reference an existing Secret that contains config.toml.
+  # Only applicable when `asSecret: true`.
+  # If `name` is empty, a Secret is generated from the `app` and `providers` values below.
+  existingSecret:
+    # -- Name of the existing Secret. Leave empty to generate one automatically.
+    name: ""
+    # -- Key within the existing Secret that holds the config.toml content.
+    key: "config.toml"
+
 # -- Application configuration block
 # @default -- See below
 app:
@@ -70,7 +92,7 @@ image:
 
 # -- Arguments to pass to the calert binary
 args:
-- "--config=/app/config.toml"
+  - "--config=/app/config.toml"
 
 # -- Override the name of the chart
 nameOverride: ""


### PR DESCRIPTION
While handling #112, when deploying, I decided to use the helm chart provided in this repo, but wanted to use k8s secrets for the config. So I updated the helm chart so that it behaves the same as before by default, but the user can opt to use a secret for config, or can provide their own pre-existing secret. I added `env` while I was at it.